### PR TITLE
[RFR]: Use basic formatter for logs

### DIFF
--- a/check-osp/osp_logconf/local_config.ini
+++ b/check-osp/osp_logconf/local_config.ini
@@ -19,9 +19,9 @@ args=(sys.stderr,)
 
 [handler_fileHandler]
 class=FileHandler
-level=DEBUG
+level=INFO
 formatter=formatter
-args=("osp-checks-" + time.strftime("%Y-%m-%d") + ".log", "a")
+args=("osp-checks.log", "a")
 
 [formatter_formatter]
 format=[%(asctime)s %(filename)-17s %(levelname)-7s] %(message)s

--- a/check-osp/osp_logconf/logging_config.ini
+++ b/check-osp/osp_logconf/logging_config.ini
@@ -19,9 +19,9 @@ args=(sys.stderr,)
 
 [handler_fileHandler]
 class=FileHandler
-level=DEBUG
+level=INFO
 formatter=formatter
-args=("/var/log/shinken/osp-checks-" + time.strftime("%Y-%m-%d") + ".log", "a")
+args=("/var/log/shinken/osp-checks.log", "a")
 
 [formatter_formatter]
 format=[%(asctime)s %(filename)-17s %(levelname)-7s] %(message)s


### PR DESCRIPTION
Going to use `logrotate` to rotate these out.

This allows for py3 compatibility as well. 